### PR TITLE
feat(web): add ZStandard (Zstd) compression for web frontend

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,5 +43,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
+    <PackageVersion Include="ZstdSharp.Port" Version="0.8.1" />
   </ItemGroup>
 </Project>

--- a/src/Squidlr.Api/packages.lock.json
+++ b/src/Squidlr.Api/packages.lock.json
@@ -1382,7 +1382,8 @@
           "Microsoft.ApplicationInsights.Profiler.AspNetCore": "[2.7.1, )",
           "Microsoft.IdentityModel.JsonWebTokens": "[7.6.3, )",
           "System.IdentityModel.Tokens.Jwt": "[7.6.3, )",
-          "System.Text.Json": "[8.0.4, )"
+          "System.Text.Json": "[8.0.4, )",
+          "ZstdSharp.Port": "[0.8.1, )"
         }
       },
       "Azure.Identity": {
@@ -1595,6 +1596,12 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
+      },
+      "ZstdSharp.Port": {
+        "type": "CentralTransitive",
+        "requested": "[0.8.1, )",
+        "resolved": "0.8.1",
+        "contentHash": "19tNz33kn2EkyViFXuxfVn338UJaRmkwBphVqP2dVJIYQUQgFrgG5h061mxkRRg1Ax6r+6WOj1FxaFZ5qaWqqg=="
       }
     }
   }

--- a/src/Squidlr.Hosting/Compression/ZStdCompressionProvider.cs
+++ b/src/Squidlr.Hosting/Compression/ZStdCompressionProvider.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Options;
+using ZstdSharp;
+
+namespace Squidlr.Hosting.Compression;
+
+/// <summary>
+/// ZStandard compression provider.
+/// </summary>
+public sealed class ZstdCompressionProvider : ICompressionProvider
+{
+    /// <inheritdoc />
+    public string EncodingName { get; } = "zstd";
+
+    /// <inheritdoc />
+    public bool SupportsFlush { get; } = true;
+
+    private ZstdCompressionProviderOptions Options { get; }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ZstdCompressionProvider"/> with options.
+    /// </summary>
+    /// <param name="options">The options for this instance.</param>
+    public ZstdCompressionProvider(IOptions<ZstdCompressionProviderOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        Options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public Stream CreateStream(Stream outputStream)
+    {
+        var level = ZstdUtils.GetQualityFromCompressionLevel(Options.Level);
+        return new CompressionStream(outputStream, level: level, leaveOpen: true);
+    }
+}

--- a/src/Squidlr.Hosting/Compression/ZStdCompressionProviderOptions.cs
+++ b/src/Squidlr.Hosting/Compression/ZStdCompressionProviderOptions.cs
@@ -1,0 +1,18 @@
+﻿using System.IO.Compression;
+using Microsoft.Extensions.Options;
+
+namespace Squidlr.Hosting.Compression;
+
+/// <summary>
+/// Options for the <see cref="ZstdCompressionProvider"/>
+/// </summary>
+public sealed class ZstdCompressionProviderOptions : IOptions<ZstdCompressionProviderOptions>
+{
+    /// <summary>
+    /// What level of compression to use for the stream. The default is <see cref="CompressionLevel.Fastest"/>.
+    /// </summary>
+    public CompressionLevel Level { get; set; } = CompressionLevel.Fastest;
+
+    /// <inheritdoc />
+    ZstdCompressionProviderOptions IOptions<ZstdCompressionProviderOptions>.Value => this;
+}

--- a/src/Squidlr.Hosting/Compression/ZStdUtils.cs
+++ b/src/Squidlr.Hosting/Compression/ZStdUtils.cs
@@ -1,0 +1,15 @@
+﻿using System.IO.Compression;
+
+namespace Squidlr.Hosting.Compression;
+
+internal static class ZstdUtils
+{
+    internal static int GetQualityFromCompressionLevel(CompressionLevel compressionLevel) => compressionLevel switch
+    {
+        CompressionLevel.NoCompression => 0,
+        CompressionLevel.Fastest => 1,
+        CompressionLevel.Optimal => 5,
+        CompressionLevel.SmallestSize => 19,
+        _ => throw new ArgumentOutOfRangeException(nameof(compressionLevel))
+    };
+}

--- a/src/Squidlr.Hosting/Squidlr.Hosting.csproj
+++ b/src/Squidlr.Hosting/Squidlr.Hosting.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Squidlr.Hosting/packages.lock.json
+++ b/src/Squidlr.Hosting/packages.lock.json
@@ -95,6 +95,12 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
+      "ZstdSharp.Port": {
+        "type": "Direct",
+        "requested": "[0.8.1, )",
+        "resolved": "0.8.1",
+        "contentHash": "19tNz33kn2EkyViFXuxfVn338UJaRmkwBphVqP2dVJIYQUQgFrgG5h061mxkRRg1Ax6r+6WOj1FxaFZ5qaWqqg=="
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.40.0",

--- a/src/Squidlr.Web/Program.cs
+++ b/src/Squidlr.Web/Program.cs
@@ -139,7 +139,6 @@ public partial class Program
             }
             else
             {
-                app.UseResponseCompression();
                 app.UseDeveloperExceptionPage();
             }
 

--- a/src/Squidlr.Web/Program.cs
+++ b/src/Squidlr.Web/Program.cs
@@ -1,6 +1,8 @@
+using System.IO.Compression;
 using System.Net;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -8,6 +10,7 @@ using Microsoft.Net.Http.Headers;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+using Squidlr.Hosting.Compression;
 using Squidlr.Hosting.Telemetry;
 using Squidlr.Web.Bootstrapping;
 using Squidlr.Web.Telemetry;
@@ -76,7 +79,19 @@ public partial class Program
                 options.HeaderName = "X-XSRF-TOKEN";
                 options.SuppressXFrameOptionsHeader = false;
             });
-            builder.Services.AddResponseCompression(options => options.EnableForHttps = true);
+
+            builder.Services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+                options.Providers.Add<ZstdCompressionProvider>();
+                options.Providers.Add<BrotliCompressionProvider>();
+                options.Providers.Add<GzipCompressionProvider>();
+            });
+
+            builder.Services.Configure<ZstdCompressionProviderOptions>(options =>
+            {
+                options.Level = CompressionLevel.Optimal;
+            });
 
             builder.Services.AddSquidlrWeb(builder.Configuration);
 
@@ -124,6 +139,7 @@ public partial class Program
             }
             else
             {
+                app.UseResponseCompression();
                 app.UseDeveloperExceptionPage();
             }
 

--- a/src/Squidlr.Web/packages.lock.json
+++ b/src/Squidlr.Web/packages.lock.json
@@ -1367,7 +1367,8 @@
           "Microsoft.ApplicationInsights.Profiler.AspNetCore": "[2.7.1, )",
           "Microsoft.IdentityModel.JsonWebTokens": "[7.6.3, )",
           "System.IdentityModel.Tokens.Jwt": "[7.6.3, )",
-          "System.Text.Json": "[8.0.4, )"
+          "System.Text.Json": "[8.0.4, )",
+          "ZstdSharp.Port": "[0.8.1, )"
         }
       },
       "Azure.Identity": {
@@ -1580,6 +1581,12 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
+      },
+      "ZstdSharp.Port": {
+        "type": "CentralTransitive",
+        "requested": "[0.8.1, )",
+        "resolved": "0.8.1",
+        "contentHash": "19tNz33kn2EkyViFXuxfVn338UJaRmkwBphVqP2dVJIYQUQgFrgG5h061mxkRRg1Ax6r+6WOj1FxaFZ5qaWqqg=="
       }
     }
   }

--- a/test/Squidlr.Api.IntegrationTests/packages.lock.json
+++ b/test/Squidlr.Api.IntegrationTests/packages.lock.json
@@ -1464,7 +1464,8 @@
           "Microsoft.ApplicationInsights.Profiler.AspNetCore": "[2.7.1, )",
           "Microsoft.IdentityModel.JsonWebTokens": "[7.6.3, )",
           "System.IdentityModel.Tokens.Jwt": "[7.6.3, )",
-          "System.Text.Json": "[8.0.4, )"
+          "System.Text.Json": "[8.0.4, )",
+          "ZstdSharp.Port": "[0.8.1, )"
         }
       },
       "Azure.Identity": {
@@ -1744,6 +1745,12 @@
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
+      },
+      "ZstdSharp.Port": {
+        "type": "CentralTransitive",
+        "requested": "[0.8.1, )",
+        "resolved": "0.8.1",
+        "contentHash": "19tNz33kn2EkyViFXuxfVn338UJaRmkwBphVqP2dVJIYQUQgFrgG5h061mxkRRg1Ax6r+6WOj1FxaFZ5qaWqqg=="
       }
     }
   }


### PR DESCRIPTION
adds zstd compression by utilizing the OSS [ZstdSharp](https://github.com/oleg-st/ZstdSharp) library